### PR TITLE
Comment cover photo part

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -441,7 +441,9 @@ class main_listener implements EventSubscriberInterface
 		));
 
 	}
-
+                /****************************
+		* COVER PHOTO *
+		****************************/
 	public function ucp_profile_modify_profile_info($event)
 	{
 		$data = $event['data'];


### PR DESCRIPTION
Please, add reset photo option. 

I guess it should look like:

458
if (!preg_match('#^(http|https|ftp)://(?:(.*?\.)*?[a-z0-9\-]+?\.[a-z]{2,4}|(?:\d{1,3}\.){3,5}\d{1,3}):?([0-9]*?).*?\.(png|gif|jpg|jpeg)$#i', $coverphoto) && ($coverphoto != "")) // Or != null?
			{
...
In next else statement, $coverphoto will pass "" (default value of that sql column, I hope) if it equals to "". 